### PR TITLE
Add simple Express CRUD app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# cPoint
+# cPoint CRUD Example
+
+This project demonstrates a simple CRUD API using Express.
+
+## Setup
+
+Install dependencies (requires Node.js and npm):
+
+```bash
+npm install
+```
+
+## Running
+
+Start the server:
+
+```bash
+node index.js
+```
+
+The server listens on port `3000` by default. CRUD endpoints are available under `/items`.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+let items = [];
+let idCounter = 1;
+
+// Create item
+app.post('/items', (req, res) => {
+  const item = { id: idCounter++, ...req.body };
+  items.push(item);
+  res.status(201).json(item);
+});
+
+// Read all items
+app.get('/items', (req, res) => {
+  res.json(items);
+});
+
+// Read single item
+app.get('/items/:id', (req, res) => {
+  const item = items.find(i => i.id === parseInt(req.params.id));
+  if (!item) return res.status(404).send('Item not found');
+  res.json(item);
+});
+
+// Update item
+app.put('/items/:id', (req, res) => {
+  const item = items.find(i => i.id === parseInt(req.params.id));
+  if (!item) return res.status(404).send('Item not found');
+  Object.assign(item, req.body);
+  res.json(item);
+});
+
+// Delete item
+app.delete('/items/:id', (req, res) => {
+  const index = items.findIndex(i => i.id === parseInt(req.params.id));
+  if (index === -1) return res.status(404).send('Item not found');
+  const deleted = items.splice(index, 1);
+  res.json(deleted[0]);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cpoint",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add Express-based CRUD server example
- document setup and usage in README
- define `start` script and Express dependency in package.json
- ignore node_modules folder

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_684fe74c01348322be0bbee68e095b36